### PR TITLE
Ensure a group called "granted:administrators" cannot be created.

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,7 @@
 package gconfig
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,6 +53,10 @@ func (c *Config) Validate() error {
 			err := fmt.Errorf("duplicate group ID %s", g.ID)
 			err = printLintError(g, err)
 			errs = multierror.Append(errs, err)
+		}
+		if g.Name == "granted:administrators" {
+			err := errors.New("a group called `granted:administrators` cannot be created. Please choose a different name")
+			return err
 		}
 
 		for _, m := range g.Members {

--- a/validate_test.go
+++ b/validate_test.go
@@ -108,3 +108,24 @@ func TestValidAccounts(t *testing.T) {
 	err = c.Validate()
 	assert.NoError(t, err)
 }
+
+func TestGrantedAdministratorsGroupCannotBeCreated(t *testing.T) {
+	str := `admins:
+- a@test.com
+
+groups:
+- name: granted:administrators
+  id: gadmins
+  members:
+    - a@test.com
+`
+
+	c, err := parseContents("config.yml", []byte(str), &gconfigv1alpha1.Providers{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errs := c.Validate()
+	assert.Equal(t, "a group called `granted:administrators` cannot be created. Please choose a different name", errs.Error())
+}
+


### PR DESCRIPTION
Return an error if a user tries to create a group called `granted:administrators`.
Include a unit test for this.